### PR TITLE
Update to Spine `1.2.0`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@
 //
 
 plugins {
-    id 'io.spine.tools.gradle.bootstrap' version '1.1.4' apply false
+    id 'io.spine.tools.gradle.bootstrap' version '1.2.0' apply false
     id 'net.ltgt.errorprone' version '1.1.1' apply false
 }
 
@@ -44,7 +44,7 @@ dependencies {
     errorproneJavac "com.google.errorprone:javac:9+181-r4173-1"
 
     implementation "com.google.guava:guava:28.1-jre"
-    implementation "org.checkerframework:checker-qual:2.11.1"
+    implementation "org.checkerframework:checker-qual:3.0.0"
 
     testImplementation "io.spine:spine-testutil-server:${spine.version()}"
 }


### PR DESCRIPTION
This PR updates the example to Spine `1.2.0`.

It also updates the `checker-qual` dependency `2.11.1` -> `3.0.0`.