### PR TITLE
Change order of tests

### DIFF
--- a/src/test/java/io/spine/helloworld/server/hello/HelloContextTest.java
+++ b/src/test/java/io/spine/helloworld/server/hello/HelloContextTest.java
@@ -55,19 +55,7 @@ class HelloContextTest extends ContextAwareTest {
             context().receivesCommand(command);
         }
 
-        @Test
-        @DisplayName("updating the `Console` entity")
-        void entity() {
-            Output expected = Output
-                    .newBuilder()
-                    .setUsername(command.getUsername())
-                    .addLines(command.getText())
-                    .vBuild();
-            context().assertState(command.getUsername(), expected);
-        }
-
-        @Test
-        @DisplayName("emitting the `Printed` event")
+        @Test @DisplayName("emitting the `Printed` event")
         void event() {
             Printed expected = Printed
                     .newBuilder()
@@ -75,6 +63,16 @@ class HelloContextTest extends ContextAwareTest {
                     .setText(command.getText())
                     .build();
             context().assertEvent(expected);
+        }
+
+        @Test @DisplayName("updating the `Console` entity")
+        void entity() {
+            Output expected = Output
+                    .newBuilder()
+                    .setUsername(command.getUsername())
+                    .addLines(command.getText())
+                    .vBuild();
+            context().assertState(command.getUsername(), expected);
         }
     }
 }

--- a/src/test/java/io/spine/helloworld/server/hello/HelloContextTest.java
+++ b/src/test/java/io/spine/helloworld/server/hello/HelloContextTest.java
@@ -47,8 +47,7 @@ class HelloContextTest extends ContextAwareTest {
 
         @BeforeEach
         void sendCommand() {
-            command = Print
-                    .newBuilder()
+            command = Print.newBuilder()
                     .setUsername(randomString())
                     .setText(randomString())
                     .vBuild();
@@ -57,8 +56,7 @@ class HelloContextTest extends ContextAwareTest {
 
         @Test @DisplayName("emitting the `Printed` event")
         void event() {
-            Printed expected = Printed
-                    .newBuilder()
+            Printed expected = Printed.newBuilder()
                     .setUsername(command.getUsername())
                     .setText(command.getText())
                     .build();
@@ -67,8 +65,7 @@ class HelloContextTest extends ContextAwareTest {
 
         @Test @DisplayName("updating the `Console` entity")
         void entity() {
-            Output expected = Output
-                    .newBuilder()
+            Output expected = Output.newBuilder()
                     .setUsername(command.getUsername())
                     .addLines(command.getText())
                     .vBuild();


### PR DESCRIPTION
This PR:
  * Puts the testing of the event generation first. It's more important than testing of the entity state.
  * Put test method annotations on the same line to be able to reference them from `embed-code/start`. See [this issue](https://github.com/SpineEventEngine/embed-code/issues/22) for details on why this is needed.
